### PR TITLE
using search_provisioned_products instead of scan_provisioned_products

### DIFF
--- a/lambdas/stepfunctions/CTE_CreateAccountFn/src/helper.py
+++ b/lambdas/stepfunctions/CTE_CreateAccountFn/src/helper.py
@@ -49,7 +49,9 @@ def scan_provisioned_products(search_pp_name, client: boto3.client) -> dict:
 
 
 def search_provisioned_products(search_pp_name, client: boto3.client) -> dict:
-    """Search for existing Service Catalog Provisioned Products
+    """Search for existing Service Catalog Provisioned Products. If it's not found
+        then will search for any in-progress deployments since Control Tower has a
+        serial method of deploying accounts.
 
     Args:
         search_pp_name (str): Service Catalog Provisioned Product Name to search for
@@ -75,6 +77,12 @@ def search_provisioned_products(search_pp_name, client: boto3.client) -> dict:
         # Removing Create time since it doesn't serializable JSON well
         del provisioned_product['CreatedTime']
         return provisioned_product
+    else:
+        # If the product has not been provisioned yet, Since Control Tower has a serial method of deploying
+        # account this statement will check to see if there's and existing In-Progress deployment and will
+        # return provision the product name / status
+        logger.info(f"Did not find {search_pp_name}. Searching for any In-Progress Control Tower Deployments")
+        return scan_provisioned_products(search_pp_name, client)
 
 
 def build_service_catalog_parameters(parameters: dict) -> list:

--- a/lambdas/stepfunctions/CTE_CreateAccountFn/src/helper.py
+++ b/lambdas/stepfunctions/CTE_CreateAccountFn/src/helper.py
@@ -48,6 +48,35 @@ def scan_provisioned_products(search_pp_name, client: boto3.client) -> dict:
                     return x
 
 
+def search_provisioned_products(search_pp_name, client: boto3.client) -> dict:
+    """Search for existing Service Catalog Provisioned Products
+
+    Args:
+        search_pp_name (str): Service Catalog Provisioned Product Name to search for
+        client (boto3.client): Boto3 Client for Service Catalog
+
+    Returns:
+        dict: Service Catalog Provisioned
+    """
+    logger.info(f"Searching for {search_pp_name}")
+    response = client.search_provisioned_products(
+        AccessLevelFilter={
+            'Key': 'Account',
+            'Value': 'self'
+        },
+        Filters={
+            'SearchQuery': [f"name:{search_pp_name}"]
+        }
+    )
+    if len(response['ProvisionedProducts']) > 0:
+        provisioned_product = response['ProvisionedProducts'][0]
+        logger.info(f"Found {provisioned_product}")
+
+        # Removing Create time since it doesn't serializable JSON well
+        del provisioned_product['CreatedTime']
+        return provisioned_product
+
+
 def build_service_catalog_parameters(parameters: dict) -> list:
     """Updates the format of the parameters to allow Service Catalog to consume them
 

--- a/lambdas/stepfunctions/CTE_CreateAccountFn/src/main.py
+++ b/lambdas/stepfunctions/CTE_CreateAccountFn/src/main.py
@@ -10,7 +10,7 @@ import time
 import random
 import boto3
 import cfnresponse
-from helper import scan_provisioned_products, build_service_catalog_parameters, create_provision_product, \
+from helper import search_provisioned_products, build_service_catalog_parameters, create_provision_product, \
     get_provisioning_artifact_id
 
 logging.basicConfig()
@@ -51,7 +51,7 @@ def lambda_handler(event, context):
         logger.info(f"Sleeping for {sleep_time} to help reduce duplicate executions")
         time.sleep(sleep_time)
 
-        provisioned_product = scan_provisioned_products(
+        provisioned_product = search_provisioned_products(
             search_pp_name=resource_prop['ServiceCatalogParameters']['AccountName'],
             client=sc_client
         )


### PR DESCRIPTION
*Issue #, if available:*
If there are the multiple CONTROL_TOWER_ACCOUNT type Provisioned Products and they are not all in Available state, the scan_provisioned_products function can return the wrong value.
Example:
4 CONTROL_TOWER_ACCOUNT
ent-shared-depl - Available
ent-shared-prod - Available
ent-shared-test - Available
ent-shared-dev - Under Change

In the above scenario, using the scan_provisioned_products function to check on ent-shared-prod, it will return the status of ent-shared-dev instead presumably due to the order in which the pagination/looping happens.

*Description of changes:*
I created a new function called "search_provisioned_products" which uses the boto3 servicecatalog search_provisioned_products api and supply it with the name of the provisioned product to filter on. If it is found, the CreatedTime key is removed since it does not serialize in JSON and it is returned. If it is not found, the function does not return anything.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
